### PR TITLE
Small improvements following scratchpad feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ x = 2 + 2 -- = 4
 y = x * pi -- = 12.5663706144
 ```
 
+## 📝 Scratchpad
+
+Floating buffer for live calculations with virtual text results. Use `:Calcium scratchpad` or `require("calcium").scratchpad()` to open, `q` to close.
+
+The `ans` variable stores the last calculation result for use in subsequent expressions.
+
+**Example:**
+```
+16 + 4         -- = 20
+ans / 4        -- = 5
+sqrt(ans)      -- = 2.2360679775
+```
+
 #### 𝑓 Available functions
 
 - **Trigonometry**: `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`

--- a/README.md
+++ b/README.md
@@ -30,12 +30,16 @@ A powerful [`lua-lib-math`](https://www.lua.org/pil/18.html) in-buffer calculato
   cmd = { "Calcium" },
   opts = {
     -- default configuration
-    notifications = true, -- notify result
-    default_mode = "append", -- or `replace` the expression
-	scratchpad = {
-		border = "rounded", -- scratchpad border style, :help 'winborder' 
-		virtual_text_format = " = %s", -- scratchpad virtual text format
-	},
+    notifications = true,                 -- notify result
+    default_mode = "append",              -- or `replace` the expression
+    scratchpad = {
+        border = "rounded",               -- floating window border style, :help 'winborder' 
+        virtual_text = {
+            format = " = %s",             -- virtual text format
+            highlight_group = "Comment",  -- virtual text highlight group
+        },
+        result_variable = "ans"           -- name of the variable for the last computation result
+    },
   },
   keys = {
     -- example keymap

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A powerful [`lua-lib-math`](https://www.lua.org/pil/18.html) in-buffer calculato
     scratchpad = {
         border = "rounded",               -- floating window border style, :help 'winborder' 
         virtual_text = {
-            format = " = %s",             -- virtual text format
+            format = "= %s",              -- virtual text format
             highlight_group = "Comment",  -- virtual text highlight group
         },
         result_variable = "ans"           -- name of the variable for the last computation result

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ A powerful [`lua-lib-math`](https://www.lua.org/pil/18.html) in-buffer calculato
     -- default configuration
     notifications = true, -- notify result
     default_mode = "append", -- or `replace` the expression
+	scratchpad = {
+		border = "rounded", -- scratchpad border style, :help 'winborder' 
+		virtual_text_format = " = %s", -- scratchpad virtual text format
+	},
   },
   keys = {
     -- example keymap

--- a/lua/calcium/config.lua
+++ b/lua/calcium/config.lua
@@ -5,7 +5,11 @@ M.defaults = {
 	default_mode = "append",
 	scratchpad = {
 		border = "rounded",
-		virtual_text_format = " = %s",
+		virtual_text = {
+			format = " = %s",
+			highlight_group = "Comment",
+		},
+		result_variable = "ans",
 	},
 }
 

--- a/lua/calcium/config.lua
+++ b/lua/calcium/config.lua
@@ -6,7 +6,7 @@ M.defaults = {
 	scratchpad = {
 		border = "rounded",
 		virtual_text = {
-			format = " = %s",
+			format = "= %s",
 			highlight_group = "Comment",
 		},
 		result_variable = "ans",

--- a/lua/calcium/config.lua
+++ b/lua/calcium/config.lua
@@ -5,6 +5,7 @@ M.defaults = {
 	default_mode = "append",
 	scratchpad = {
 		border = "rounded",
+		virtual_text_format = " = %s",
 	},
 }
 

--- a/lua/calcium/scratchpad.lua
+++ b/lua/calcium/scratchpad.lua
@@ -96,6 +96,10 @@ function M.create_scratchpad()
 
 	state.buf, state.win = setup_window()
 
+	-- Keymaps
+	local map_opts = { buffer = state.buf, silent = true }
+	vim.keymap.set("n", "q", M.close_scratchpad, map_opts)
+
 	-- Autocmds
 	vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
 		group = vim.api.nvim_create_augroup("CalciumFloating", { clear = true }),

--- a/lua/calcium/scratchpad.lua
+++ b/lua/calcium/scratchpad.lua
@@ -72,13 +72,16 @@ function M.evaluate_scratchpad()
 
 	vim.api.nvim_buf_clear_namespace(state.buf, state.ns, 0, -1)
 
+	local previous_evaluation = nil
 	local variables = calculator.extract_variables(lines)
 
 	for i, line in ipairs(lines) do
 		if line ~= "" then
+			variables["_"] = previous_evaluation
 			local success, result = calculator.evaluate_expression(line, variables)
 			if success then
 				render_result(i - 1, calculator.format_result(result), #line)
+				previous_evaluation = result
 			end
 		end
 	end

--- a/lua/calcium/scratchpad.lua
+++ b/lua/calcium/scratchpad.lua
@@ -6,7 +6,7 @@ local config = require("calcium.config")
 local state = {
 	buf = nil,
 	win = nil,
-	ns = vim.api.nvim_create_namespace("CalciumGhost"),
+	ns = vim.api.nvim_create_namespace("CalciumVirtualText"),
 }
 
 local function is_valid(win)
@@ -55,8 +55,9 @@ end
 
 -- Helper to render virtual text results
 local function render_result(line_idx, text, col)
+	local vt_config = config.options.scratchpad.virtual_text
 	vim.api.nvim_buf_set_extmark(state.buf, state.ns, line_idx, col, {
-		virt_text = { { "= " .. text, "Comment" } },
+		virt_text = { { string.format(vt_config.format, text), vt_config.highlight_group } },
 		virt_text_pos = "eol",
 		hl_mode = "combine",
 	})
@@ -72,16 +73,16 @@ function M.evaluate_scratchpad()
 
 	vim.api.nvim_buf_clear_namespace(state.buf, state.ns, 0, -1)
 
-	local previous_evaluation = nil
+	local last_result = nil
 	local variables = calculator.extract_variables(lines)
 
 	for i, line in ipairs(lines) do
 		if line ~= "" then
-			variables["_"] = previous_evaluation
+			variables[config.options.scratchpad.result_variable] = last_result
 			local success, result = calculator.evaluate_expression(line, variables)
 			if success then
 				render_result(i - 1, calculator.format_result(result), #line)
-				previous_evaluation = result
+				last_result = result
 			end
 		end
 	end

--- a/lua/calcium/scratchpad.lua
+++ b/lua/calcium/scratchpad.lua
@@ -95,10 +95,6 @@ function M.create_scratchpad()
 
 	state.buf, state.win = setup_window()
 
-	-- Keymaps
-	local map_opts = { buffer = state.buf, silent = true }
-	vim.keymap.set("n", "q", M.close_scratchpad, map_opts)
-
 	-- Autocmds
 	vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
 		group = vim.api.nvim_create_augroup("CalciumFloating", { clear = true }),

--- a/lua/calcium/scratchpad.lua
+++ b/lua/calcium/scratchpad.lua
@@ -41,7 +41,7 @@ local function setup_window()
 		height = height,
 		row = math.floor((ui.height - height) / 2),
 		col = math.floor((ui.width - width) / 2),
-		border = config.options.scratchpad.border or "rounded",
+		border = config.options.scratchpad.border,
 		style = "minimal",
 		title = " Calcium ",
 		title_pos = "center",


### PR DESCRIPTION
- Introduce a special variable `_` that will be automatically set to the result of the preceding line.
- Remove the `q` keybind since you seems to prefer to not set them at plugin level
- Introduce a config key `scratchpad.virtual_text_format` (so i can use a double space :smiley:)