### PR TITLE
Implement highlights in scratchpad filetype

### DIFF
--- a/lua/calcium/scratchpad.lua
+++ b/lua/calcium/scratchpad.lua
@@ -56,8 +56,8 @@ end
 -- Helper to render virtual text results
 local function render_result(line_idx, text, col)
 	vim.api.nvim_buf_set_extmark(state.buf, state.ns, line_idx, col, {
-		virt_text = { { " = " .. text, "Comment" } },
-		virt_text_pos = "inline",
+		virt_text = { { "= " .. text, "Comment" } },
+		virt_text_pos = "eol",
 		hl_mode = "combine",
 	})
 end

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -16,4 +16,10 @@ syntax region calciumResult
 syntax match calciumResultNumber /\v\d+(\.\d+)?>/ contained
 highlight default link calciumResultNumber Special
 
+" Functions
+syntax match calciumFunctionCall /\v<[a-zA-Z_]\w*\(/ contains=calciumFunctionName
+" Highlight only the name part
+syntax match calciumFunctionName /\v<[a-zA-Z_]\w*/ contained
+highlight default link calciumFunctionName Function
+
 let b:current_syntax = "calcium"

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -16,10 +16,19 @@ syntax region calciumResult
 syntax match calciumResultNumber /\v\d+(\.\d+)?>/ contained
 highlight default link calciumResultNumber Special
 
-" Functions
-syntax match calciumFunctionCall /\v<[a-zA-Z_]\w*\(/ contains=calciumFunctionName
-" Highlight only the name part
+" Function call region: name(...)
+syntax region calciumFunctionCall
+  \ start=/\v<[a-zA-Z_]\w*\(/
+  \ end=/)/
+  \ contains=calciumFunctionName,calciumFuncParen,calciumNumber
+  \ keepend
+
+" Function name
 syntax match calciumFunctionName /\v<[a-zA-Z_]\w*/ contained
 highlight default link calciumFunctionName Function
+
+" Function parentheses
+syntax match calciumFuncParen /[()]/ contained
+highlight default link calciumFuncParen Delimiter
 
 let b:current_syntax = "calcium"

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -1,0 +1,19 @@
+if exists("b:current_syntax")
+  finish
+endif
+
+" Integers and floats
+syntax match calciumNumber /\v<\d+(\.\d+)?>/
+highlight default link calciumNumber Number
+
+" Result
+syntax region calciumResult
+  \ start=/=/
+  \ end=/$/
+  \ contains=calciumResultNumber
+  \ keepend
+
+syntax match calciumResultNumber /\v\d+(\.\d+)?>/ contained
+highlight default link calciumResultNumber Special
+
+let b:current_syntax = "calcium"

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -15,17 +15,8 @@ else
 endif
 
 " Result
-syntax region calciumResult
-      \ start=/\v[^=~><][=]\s*\zs[a-zA-Z0-9]/
-      \ end=/$/
-      \ contains=calciumResultNumber,calciumResultBoolean
-      \ keepend
-
-syntax match calciumResultNumber /\v\d+(\.\d+)?>/ contained
-highlight default link calciumResultNumber Special
-
-syntax match calciumResultBoolean /\v<(true|false)>/ contained
-highlight default link calciumResultBoolean Special
+syntax match calciumResult /\v[^=~<>][=]\s*\zs[a-zA-Z0-9\.]*/
+highlight default link calciumResult Special
 
 " Brackets
 syntax match calciumBracket /[()\[\]{}]/

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -11,7 +11,7 @@ syntax match calciumVariable /\v<[a-zA-Z_]\w*>/
 if hlexists('@variable.member')
   highlight default link calciumVariable @variable.member
 else
-  highlight default link calciumVariable DiagnosticHint
+  highlight default link calciumVariable Character
 endif
 
 " Result

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -37,14 +37,18 @@ endif
 
 " Function call region: name(...)
 syntax region calciumFunctionCall
-  \ start=/\v<[a-zA-Z_]\w*\(/
-  \ end=/)/
-  \ contains=calciumFunctionName,calciumFuncParen,calciumNumber
-  \ keepend
+      \ start=/\v<[a-zA-Z_]\w*\(/
+      \ end=/)/
+      \ contains=calciumFunctionName,calciumNumber,calciumBracket,calciumVariable
+      \ keepend
 
 " Function name
 syntax match calciumFunctionName /\v<[a-zA-Z_]\w*/ contained
-highlight default link calciumFunctionName Function
+if hlexists('@keyword.function')
+  highlight default link calciumFunctionName @keyword.function
+else
+  highlight default link calciumFunctionName Function
+endif
 
 
 let b:current_syntax = "calcium"

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -35,15 +35,8 @@ else
   highlight default link calciumBracket Delimiter
 endif
 
-" Function call region: name(...)
-syntax region calciumFunctionCall
-      \ start=/\v<[a-zA-Z_]\w*\(/
-      \ end=/)/
-      \ contains=calciumFunctionName,calciumNumber,calciumBracket,calciumVariable
-      \ keepend
-
 " Function name
-syntax match calciumFunctionName /\v<[a-zA-Z_]\w*/ contained
+syntax match calciumFunctionName /\v<[A-Za-z_][A-Za-z0-9_]*\ze\(/
 if hlexists('@keyword.function')
   highlight default link calciumFunctionName @keyword.function
 else

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -16,13 +16,16 @@ endif
 
 " Result
 syntax region calciumResult
-  \ start=/=/
-  \ end=/$/
-  \ contains=calciumResultNumber
-  \ keepend
+      \ start=/\v[^=~><][=]\s*\zs[a-zA-Z0-9]/
+      \ end=/$/
+      \ contains=calciumResultNumber,calciumResultBoolean
+      \ keepend
 
 syntax match calciumResultNumber /\v\d+(\.\d+)?>/ contained
 highlight default link calciumResultNumber Special
+
+syntax match calciumResultBoolean /\v<(true|false)>/ contained
+highlight default link calciumResultBoolean Special
 
 " Brackets
 syntax match calciumBracket /[()\[\]{}]/

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -16,6 +16,14 @@ syntax region calciumResult
 syntax match calciumResultNumber /\v\d+(\.\d+)?>/ contained
 highlight default link calciumResultNumber Special
 
+" Brackets
+syntax match calciumBracket /[()\[\]{}]/
+if hlexists('@punctuation.bracket')
+  highlight default link calciumBracket @punctuation.bracket
+else
+  highlight default link calciumBracket Delimiter
+endif
+
 " Function call region: name(...)
 syntax region calciumFunctionCall
   \ start=/\v<[a-zA-Z_]\w*\(/
@@ -27,8 +35,5 @@ syntax region calciumFunctionCall
 syntax match calciumFunctionName /\v<[a-zA-Z_]\w*/ contained
 highlight default link calciumFunctionName Function
 
-" Function parentheses
-syntax match calciumFuncParen /[()]/ contained
-highlight default link calciumFuncParen Delimiter
 
 let b:current_syntax = "calcium"

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -6,6 +6,14 @@ endif
 syntax match calciumNumber /\v<\d+(\.\d+)?>/
 highlight default link calciumNumber Number
 
+" Variables
+syntax match calciumVariable /\v<[a-zA-Z_]\w*>/
+if hlexists('@variable.member')
+  highlight default link calciumVariable @variable.member
+else
+  highlight default link calciumVariable DiagnosticHint
+endif
+
 " Result
 syntax region calciumResult
   \ start=/=/

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -35,6 +35,10 @@ else
   highlight default link calciumBracket Delimiter
 endif
 
+" Re-use answer
+syntax match calciumAnswer /\v<(ans|_)>/
+highlight default link calciumAnswer Special
+
 " Function name
 syntax match calciumFunctionName /\v<[A-Za-z_][A-Za-z0-9_]*\ze\(/
 if hlexists('@keyword.function')
@@ -42,9 +46,5 @@ if hlexists('@keyword.function')
 else
   highlight default link calciumFunctionName Function
 endif
-
-" Re-use answer
-syntax match calciumAnswer /\v<(ans|_)>/
-highlight default link calciumAnswer Special
 
 let b:current_syntax = "calcium"

--- a/syntax/calcium.vim
+++ b/syntax/calcium.vim
@@ -50,5 +50,8 @@ else
   highlight default link calciumFunctionName Function
 endif
 
+" Re-use answer
+syntax match calciumAnswer /\v<(ans|_)>/
+highlight default link calciumAnswer Special
 
 let b:current_syntax = "calcium"


### PR DESCRIPTION
Currently matching numbers and the result at the end of the line and adding new highlights for those using `syntax/calcium.vim`. Will also add highlighting for functions and may then try to do all this through `lua`.